### PR TITLE
调整 function () use () 中 use 换行的缩进

### DIFF
--- a/lib/rules/indent.php
+++ b/lib/rules/indent.php
@@ -336,6 +336,7 @@ class IndentRule extends Rule {
       case TokenKind::ArrowToken:
       case TokenKind::DoubleArrowToken:
       case TokenKind::ColonColonToken:
+      case TokenKind::UseKeyword:
       case TokenKind::EqualsToken:
         $this->offsets->setDesiredOffsets([$token->fullStart, $node->getEndPosition()], $token);
         break;

--- a/tests/rules/indent.php
+++ b/tests/rules/indent.php
@@ -76,7 +76,7 @@ array_map(function (\$v)
 EOF;
         $rules = ['indent' => ['error']];
         $report = processSource($source, $rules);
-        $this->assertEmpty($report->getResult()->messages);
+        $this->assertLineColumn([], $report);
     }
 
 }

--- a/tests/rules/indent.php
+++ b/tests/rules/indent.php
@@ -42,6 +42,7 @@ EOF;
 
     public function testFunctionUse()
     {
+        // wrong indent
         $source = <<<EOF
 <?php
 \$array = [
@@ -58,6 +59,24 @@ EOF;
         $rules = ['indent' => ['error']];
         $report = processSource($source, $rules);
         $this->assertLineColumn([[8, 1], [9, 1]], $report);
+
+        // correct indent
+        $source = <<<EOF
+<?php
+\$array = [
+    4,
+    5,
+];
+\$a = 1;
+array_map(function (\$v)
+        use (\$a) {
+    \$a = \$a + 1;
+    return \$v + \$a;
+}, \$array);
+EOF;
+        $rules = ['indent' => ['error']];
+        $report = processSource($source, $rules);
+        $this->assertEmpty($report->getResult()->messages);
     }
 
 }

--- a/tests/rules/indent.php
+++ b/tests/rules/indent.php
@@ -40,4 +40,24 @@ EOF;
         $this->assertLineColumn([[3, 1], [5, 1], [7, 1], [8, 1]], $report);
     }
 
+    public function testFunctionUse()
+    {
+        $source = <<<EOF
+<?php
+\$array = [
+    4,
+    5,
+];
+\$a = 1;
+array_map(function (\$v)
+    use (\$a) {
+        \$a = \$a + 1;
+    return \$v + \$a;
+}, \$array);
+EOF;
+        $rules = ['indent' => ['error']];
+        $report = processSource($source, $rules);
+        $this->assertLineColumn([[8, 1], [9, 1]], $report);
+    }
+
 }


### PR DESCRIPTION
原有的 `function () use ()` 中 use 换行为以下格式：
```php
$arr = [1, 2, 3];
$a = 1;
$result = array_map(function ($item)
    use ($a) {  // 四个空格
    return $item + $a;
}, $arr);
```
调整为：
```php
$arr = [1, 2, 3];
$a = 1;
$result = array_map(function ($item)
        use ($a) {  // 八个空格
    return $item + $a;
}, $arr);
```