### PR TITLE
lib/rules: 完善注释检查

### DIFF
--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -49,9 +49,9 @@ class SpacedCommentRule extends Rule {
     }
     // check special comment pre colon
     if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE|REVIEW)(.?)/', $commentBody, $matches)) {
-      $specialCommentPre = $matches[1];
+      $specialCommentTag = $matches[1];
       if ($matches[2] !== ':') {
-        $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");
+        $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentTag' in comment.");
       }
     }
     if ($end !== -1 && strlen($commentBody) > 1) {

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -47,6 +47,13 @@ class SpacedCommentRule extends Rule {
         }
       }
     }
+    // check special comment pre colon
+    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND)([:：]).*/', $commentBody, $matches)) {
+      $specialCommentPre = $matches[1];
+      if ($matches[2] !== ':') {
+        $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");
+      }
+    }
     if ($end !== -1 && strlen($commentBody) > 1) {
       // check end
       $displayValue = substr($text, $end - 2, 2);

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -48,7 +48,7 @@ class SpacedCommentRule extends Rule {
       }
     }
     // check special comment pre colon
-    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE|REVIEW)(.?).*/', $commentBody, $matches)) {
+    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE|REVIEW)(.?)/', $commentBody, $matches)) {
       $specialCommentPre = $matches[1];
       if ($matches[2] !== ':') {
         $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -48,7 +48,7 @@ class SpacedCommentRule extends Rule {
       }
     }
     // check special comment pre colon
-    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND)(.?).*/', $commentBody, $matches)) {
+    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE)(.?).*/', $commentBody, $matches)) {
       $specialCommentPre = $matches[1];
       if ($matches[2] !== ':') {
         $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -47,7 +47,7 @@ class SpacedCommentRule extends Rule {
         }
       }
     }
-    // check special comment pre colon
+    // check special comment colon
     if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE|REVIEW)(.?)/', $commentBody, $matches)) {
       $specialCommentTag = $matches[1];
       if ($matches[2] !== ':') {

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -48,7 +48,7 @@ class SpacedCommentRule extends Rule {
       }
     }
     // check special comment pre colon
-    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND)([:：]).*/', $commentBody, $matches)) {
+    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND)(.?).*/', $commentBody, $matches)) {
       $specialCommentPre = $matches[1];
       if ($matches[2] !== ':') {
         $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");

--- a/lib/rules/spaced-comment.php
+++ b/lib/rules/spaced-comment.php
@@ -48,7 +48,7 @@ class SpacedCommentRule extends Rule {
       }
     }
     // check special comment pre colon
-    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE)(.?).*/', $commentBody, $matches)) {
+    if (preg_match('/^ (TEMP|TODO|FIXME|WORKAROUND|NOTICE|REVIEW)(.?).*/', $commentBody, $matches)) {
       $specialCommentPre = $matches[1];
       if ($matches[2] !== ':') {
         $this->report($token, $offset + $start, "Expected a half-width colon after '$specialCommentPre' in comment.");

--- a/tests/rules/spaced-comment.php
+++ b/tests/rules/spaced-comment.php
@@ -12,13 +12,15 @@ final class SpacedCommentRuleTest extends RuleTestCase {
 // TODO：xxx
 // FIXME：xxx
 // WORKAROUND：xxx
+// NOTICE：xxx
 // TEMP: xxx
 // TODO: xxx
 // FIXME: xxx
 // WORKAROUND: xxx
+// NOTICE: xxx
 EOF;
         $rules = ['spaced-comment' => ['error', 'always', ['exceptions' => '-+*']]];
         $report = processSource($source, $rules);
-        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1]], $report);
+        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1], [7, 1]], $report);
     }
 }

--- a/tests/rules/spaced-comment.php
+++ b/tests/rules/spaced-comment.php
@@ -1,0 +1,24 @@
+<?php
+
+final class SpacedCommentRuleTest extends RuleTestCase {
+
+    public $ruleId = 'spaced-comment';
+
+    public function testCheckComment() {
+        $source = <<<EOF
+<?php
+
+// TEMP：xxx
+// TODO：xxx
+// FIXME：xxx
+// WORKAROUND：xxx
+// TEMP: xxx
+// TODO: xxx
+// FIXME: xxx
+// WORKAROUND: xxx
+EOF;
+        $rules = ['spaced-comment' => ['error', 'always', ['exceptions' => '-+*']]];
+        $report = processSource($source, $rules);
+        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1]], $report);
+    }
+}

--- a/tests/rules/spaced-comment.php
+++ b/tests/rules/spaced-comment.php
@@ -8,21 +8,22 @@ final class SpacedCommentRuleTest extends RuleTestCase {
         $source = <<<EOF
 <?php
 
-// TEMP：xxx
-// TODO：xxx
-// FIXME：xxx
-// WORKAROUND：xxx
-// NOTICE：xxx
-// REVIEW：xxx
-// TEMP: xxx
-// TODO: xxx
-// FIXME: xxx
-// WORKAROUND: xxx
-// NOTICE: xxx
-// REVIEW: xxx
+//TEMP: xx error
+// TEMP：xxx error
+// TODO：xxx error
+// FIXME：xxx error
+// WORKAROUND：xxx error
+// NOTICE：xxx error
+// REVIEW：xxx error
+// TEMP: xxx correct
+// TODO: xxx correct
+// FIXME: xxx correct
+// WORKAROUND: xxx correct
+// NOTICE: xxx correct
+// REVIEW: xxx correct
 EOF;
         $rules = ['spaced-comment' => ['error', 'always', ['exceptions' => '-+*']]];
         $report = processSource($source, $rules);
-        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1], [7, 1], [8, 1]], $report);
+        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1], [7, 1], [8, 1], [9, 1]], $report);
     }
 }

--- a/tests/rules/spaced-comment.php
+++ b/tests/rules/spaced-comment.php
@@ -13,14 +13,16 @@ final class SpacedCommentRuleTest extends RuleTestCase {
 // FIXME：xxx
 // WORKAROUND：xxx
 // NOTICE：xxx
+// REVIEW：xxx
 // TEMP: xxx
 // TODO: xxx
 // FIXME: xxx
 // WORKAROUND: xxx
 // NOTICE: xxx
+// REVIEW: xxx
 EOF;
         $rules = ['spaced-comment' => ['error', 'always', ['exceptions' => '-+*']]];
         $report = processSource($source, $rules);
-        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1], [7, 1]], $report);
+        $this->assertLineColumn([[3, 1], [4, 1], [5, 1], [6, 1], [7, 1], [8, 1]], $report);
     }
 }


### PR DESCRIPTION
- 需求：检查特殊注释（TEMP、TODO、FIXME、WORKAROUND）后的冒号需要为半角冒号
- 效果展示
  <img width="720" alt="wecom-temp-70aa75602d0f2d81b6ac3e354551fb0c" src="https://github.com/tengattack/phplint/assets/26989449/ee107725-30a3-4d0f-b73c-e68bf0017fd1">
